### PR TITLE
HIB-7 added kevs.env to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 # flyctl launch added from .gitignore
 fly.toml
+keys.env


### PR DESCRIPTION
we have implemented they ENV variables in fly.io